### PR TITLE
Update sentry-raven to allow 3.x

### DIFF
--- a/foreman_concrete.gemspec
+++ b/foreman_concrete.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,lib}/**/*'] + ['LICENSE', 'Rakefile', 'README.md']
 
-  s.add_runtime_dependency 'sentry-raven', '~> 2.7'
+  s.add_runtime_dependency 'sentry-raven', '>= 2.7', '< 4'
 
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'rubocop'


### PR DESCRIPTION
3.0.0 was only a major due to dropping Ruby < 2.3. Version 3.0.1 adds Rails 6 support, which is what Foreman has been using for a while. It also supports Faraday 1.x.

This doens't update to version 4.x or 5.x, which is the new SDK.

Fixes #2